### PR TITLE
feat(seed): adiciona seeder para models faltantes

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -19,3 +19,4 @@ yarn-debug.log
 *.tmp
 *.swp
 
+*TODO.md

--- a/Backend/src/database/seeders/20251007202205-demo-users.js
+++ b/Backend/src/database/seeders/20251007202205-demo-users.js
@@ -19,7 +19,7 @@ module.exports = {
         id: uuidv4(),
         name: 'Ricardo S', 
         email: 'rica.die@example.com',
-        cpf: '33122233355', 
+        cpf: '35122233355', 
         birth_date: new Date('1990-01-15'),
         phone_number: '88997731130',
         password_hash: await bcrypt.hash('teste1', saltRounds),

--- a/Backend/src/database/seeders/20251115042716-demo-vaccines.js
+++ b/Backend/src/database/seeders/20251115042716-demo-vaccines.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface) {
+    /**
+     * Insere lista de vacinas de exemplo na tabela
+    */
+    const { v4: uuidv4 } = await import('uuid');
+
+    await queryInterface.bulkInsert('vaccines', [
+      { // vacina 1
+        id: uuidv4(),
+        name: 'Vacina A',
+        manufacturer: 'Fabricante A',
+        description: 'Descricao da Vacina A',
+        dose_info: '2 doses de 0.5ml',
+        dose_interval_days: 28,
+        createdAt: new Date(),  
+        updatedAt: new Date()   
+      },
+      { // vacina 2
+        id: uuidv4(),
+        name: 'Vacina B',
+        manufacturer: 'Fabricante B',
+        description: 'Descricao da Vacina B',
+        dose_info: '1 dose de 1ml',
+        dose_interval_days: 0,
+        createdAt: new Date(),  
+        updatedAt: new Date()   
+      },
+      { // vacina 3
+        id: uuidv4(),
+        name: 'Vacina C',
+        manufacturer: 'Fabricante C',
+        description: 'Descricao da Vacina C',
+        dose_info: '3 doses de 0.3ml',
+        dose_interval_days: 21,
+        createdAt: new Date(),  
+        updatedAt: new Date()   
+      }
+    ], {});
+
+  },
+
+  async down (queryInterface) {
+    /**
+      * Remove todos os registros da tabela de vacinas
+     */
+    await queryInterface.bulkDelete('vaccines', null, {});
+  }
+};

--- a/Backend/src/database/seeders/20251115052402-demo-VaccineLot.js
+++ b/Backend/src/database/seeders/20251115052402-demo-VaccineLot.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface) {
+    /**
+     * insere lista de lotes de vacinas de exemplo na tabela
+    */
+    const { v4: uuidv4 } = await import('uuid');
+
+    // Obtém os IDs das vacinas inseridas pelo seeder de vacinas
+    const [vaccines] = await queryInterface.sequelize.query(
+      'SELECT id FROM "vaccines";'
+    );
+
+    if (!vaccines || vaccines.length < 2) {
+      throw new Error('Seeder de vacinas (demo-vaccines) não foi executado ou não criou vacinas suficientes. Rode o seeder de vacinas primeiro.');
+    }
+
+    const vacinaA_id = vaccines[0].id;
+    const vacinaB_id = vaccines[1].id;
+
+    await queryInterface.bulkInsert('vaccineLots', [
+      {
+        id: uuidv4(),
+        lot_number: 'LOT123456',
+        manufacturing_date: new Date('2023-01-01'),
+        expiry_date: new Date('2024-12-10'),
+        quantity_initial: 1000,
+        quantity_current: 800,
+        vaccine_id: vacinaA_id, 
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: uuidv4(),
+        lot_number: 'LOT654321',
+        manufacturing_date: new Date('2023-06-01'),
+        expiry_date: new Date('2025-06-01'),
+        quantity_initial: 500,
+        quantity_current: 500,  
+        vaccine_id: vacinaB_id, 
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+    ], {});
+  },
+
+  /**
+   * Remove todos os registros da tabela
+   * 
+   */
+  async down (queryInterface) {
+    await queryInterface.bulkDelete('vaccineLots', null, {});
+  }
+};

--- a/Backend/src/database/seeders/20251115053828-demo-vaccinationRecords.js
+++ b/Backend/src/database/seeders/20251115053828-demo-vaccinationRecords.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  /**
+   * Insere lista de registros de vacinacao de exemplo na tabela
+   * lOGICA ADICIONADA PARA LIDAR COM AS CHAVES ESTRANGEIRAS E ATUALIZACAO DE ESTOQUE
+   * */
+  async up (queryInterface) {
+    
+    const { v4: uuidv4 } = await import('uuid');
+    
+    // Isso garante que, se a atualização do estoque falhar, a criação do registro também será desfeita.
+    const t = await queryInterface.sequelize.transaction();
+
+    try {
+      // Busca IDs REAIS do banco de dados (criados pelos seeders anteriores)
+      const [patients] = await queryInterface.sequelize.query(
+        'SELECT id FROM "users" WHERE role = \'patient\' LIMIT 1;',
+        { transaction: t }
+      );
+      const [professionals] = await queryInterface.sequelize.query(
+        'SELECT id FROM "users" WHERE role = \'health_professional\' LIMIT 1;',
+        { transaction: t }
+      );
+      // Busca um lote que TENHA estoque
+      const [lots] = await queryInterface.sequelize.query(
+        'SELECT id FROM "vaccineLots" WHERE quantity_current > 0 LIMIT 1;',
+        { transaction: t }
+      );
+
+      // Verifica se temos os dados necessários
+      if (!patients.length || !professionals.length || !lots.length) {
+        throw new Error('Seeders de Users ou VaccineLots não criaram dados suficientes ou não há lotes com estoque.');
+      }
+
+      const patientId = patients[0].id;
+      const professionalId = professionals[0].id;
+      const lotId = lots[0].id;
+
+      await queryInterface.bulkInsert('vaccinationRecords', [
+        {
+          id: uuidv4(),
+          application_date: new Date('2023-01-15T10:00:00Z'),
+          location: 'Clinica Central (SEEDED)',
+          notes: 'Primeira dose administrada (seeder).',
+          patient_id: patientId,         
+          professional_id: professionalId, 
+          vaccine_lot_id: lotId,          
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ], { transaction: t }); // Passa a transação para o bulkInsert
+
+      // Decrementar o estoque do lote (dentro da transação)
+      await queryInterface.sequelize.query(
+        'UPDATE "vaccineLots" SET quantity_current = quantity_current - 1 WHERE id = :lotId',
+        {
+          replacements: { lotId: lotId },
+          transaction: t, // Garante que esta query faça parte da transação
+        }
+      );
+
+      await t.commit();
+
+    } catch (error) {
+      await t.rollback();
+      console.error('Erro no seeder VaccinationRecords:', error.message);
+      throw error;
+    }
+  },
+
+  /**
+   * Remove todos os registros da tabela
+   * */
+  async down (queryInterface) {
+    // O 'down' não precisa de transação, apenas deleta os registros.
+    // Não precisamos "devolver" o estoque ao deletar os registros de teste.
+    await queryInterface.bulkDelete('vaccinationRecords', null, {});
+  }
+};

--- a/Backend/src/models/vaccine.js
+++ b/Backend/src/models/vaccine.js
@@ -52,6 +52,7 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     sequelize,
     modelName: 'Vaccine',
+    tableName: 'vaccines'
   });
 
   return Vaccine;

--- a/Backend/src/models/vaccinelot.js
+++ b/Backend/src/models/vaccinelot.js
@@ -61,6 +61,7 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     sequelize,
     modelName: 'VaccineLot',
+    tableName: 'vaccineLots'
   });
 
   return VaccineLot;


### PR DESCRIPTION
Foram adicionados novos seeders no sistema para as seguintes tabelas: VaccineLot, Vaccines e VaccinesRecords.

Esses seeders vão auxiliar no desenvolvimento das proximas features do sistema, provendo conteudo nas tabelas para que possamos testar as funcionalidades sem seguir o fluxo de registro e cadastro de tudo.

Disclaimer: Fiz uma logica um pouco complicada no database/seeders/demo-vaccinationRecord.js , tive que implementar ela por conta das chaves estrangeiras, por isso deixei uma serie de comentarios explicando passo a passo.